### PR TITLE
Separate derives by comma instead of semicolon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ All user visible changes to this project will be documented in this file. This p
 ## BC Breaks
 
 - Made `for<..>` syntax in `#[delegate(derive(..))]`/`#[delegate(for(..))]` attribute arguments only for declaring additional generic parameters not present on type/trait already. ([#10])
+- Made entries in `#[delegate(derive(..))]`/`#[delegate(for(..))]` attribute arguments separated by comma instead of semicolon. ([#11])
 
 [#10]: https://github.com/arcane-rs/delegation/pull/10
+[#11]: https://github.com/arcane-rs/delegation/pull/11
 
 
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ impl Named<String> for User {
 #[delegate(derive(
     for<N> Named<N>
     where
-        U: Named<N> + 'static;
+        U: Named<N> + 'static,
 ))]
 enum Case1<U> {
     User(U),
@@ -97,7 +97,7 @@ struct Case2<U>(U);
 #[delegate(derive(
    Named<String>
    where
-       U: Named<String> + 'static;
+       U: Named<String> + 'static,
 ))]
 enum Case3<U> {
     Case1(Case1<U>),
@@ -212,8 +212,8 @@ trait AsStrDef {
 }
 
 #[delegate(derive(
-    AsRef<str> as AsRefDef;
-    AsStr as AsStrDef;
+    AsRef<str> as AsRefDef,
+    AsStr as AsStrDef,
 ))]
 enum Name {
     First(String),

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ use delegation::delegate;
 #[delegate(for(
     for<U> Case2<U>
     where
-        U: Named<N> + 'static;
+        U: Named<N> + 'static,
 ))]
 trait Named<N> {
     fn name(&self) -> N;

--- a/codegen/src/derive.rs
+++ b/codegen/src/derive.rs
@@ -15,7 +15,10 @@ use syn::{
 #[cfg(doc)]
 use syn::{Attribute, Generics, Index, Path, Type, WhereClause};
 
-use crate::{util::GenericsExt as _, MacroPath};
+use crate::{
+    util::{GenericsExt as _, WhereClauseExt as _},
+    MacroPath,
+};
 
 /// Arguments for `#[delegate]` macro expansion on types (structs or enums).
 struct Args {
@@ -634,7 +637,7 @@ impl Parse for DeriveTrait {
                 input.parse()
             })
             .transpose()?;
-        let where_clause = input.parse::<Option<syn::WhereClause>>()?;
+        let where_clause = syn::WhereClause::parse_thrifty_opt(input)?;
 
         Ok(Self { path, wrapper_ty, generics, where_clause })
     }

--- a/codegen/src/derive.rs
+++ b/codegen/src/derive.rs
@@ -20,7 +20,7 @@ use crate::{util::GenericsExt as _, MacroPath};
 /// Arguments for `#[delegate]` macro expansion on types (structs or enums).
 struct Args {
     /// `derive` attribute argument, specifying derived traits.
-    derive: Punctuated<DeriveTrait, token::Semi>,
+    derive: Punctuated<DeriveTrait, token::Comma>,
 }
 
 impl Parse for Args {

--- a/codegen/src/impl_trait/mod.rs
+++ b/codegen/src/impl_trait/mod.rs
@@ -21,14 +21,17 @@ use syn::{
 #[cfg(doc)]
 use syn::{Generics, Path, Signature, Type, Visibility, WhereClause};
 
-use crate::{util::GenericsExt as _, MacroPath};
+use crate::{
+    util::{GenericsExt as _, WhereClauseExt as _},
+    MacroPath,
+};
 
 use self::util::{GenericsExt as _, SignatureExt as _};
 
 /// Arguments of `#[delegate]` macro expansion on traits.
 struct Args {
     /// `for` attribute argument, specifying types for deriving.
-    r#for: Punctuated<ForTy, token::Semi>,
+    r#for: Punctuated<ForTy, token::Comma>,
 
     /// `as` attribute argument, specifying path to the trait this trait is
     /// referencing to.
@@ -1235,7 +1238,7 @@ impl Parse for ForTy {
             })
             .transpose()?;
         let ty = input.parse()?;
-        let where_clause = input.parse::<Option<syn::WhereClause>>()?;
+        let where_clause = syn::WhereClause::parse_thrifty_opt(input)?;
 
         Ok(Self { ty, generics, where_clause })
     }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -231,7 +231,7 @@ use self::macro_path::MacroPath;
 /// #[delegate(for(
 ///     for<U> Case2<U>
 ///     where
-///         U: Named<N> + 'static;
+///         U: Named<N> + 'static,
 /// ))]
 /// trait Named<N> {
 ///     fn name(&self) -> N;

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -247,7 +247,7 @@ use self::macro_path::MacroPath;
 /// #[delegate(derive(
 ///     for<N> Named<N>
 ///     where
-///         U: Named<N> + 'static;
+///         U: Named<N> + 'static,
 /// ))]
 /// enum Case1<U> {
 ///     User(U),
@@ -259,7 +259,7 @@ use self::macro_path::MacroPath;
 /// #[delegate(derive(
 ///    Named<String>
 ///    where
-///        U: Named<String> + 'static;
+///        U: Named<String> + 'static,
 /// ))]
 /// enum Case3<U> {
 ///     Case1(Case1<U>),
@@ -380,8 +380,8 @@ use self::macro_path::MacroPath;
 /// }
 ///
 /// #[delegate(derive(
-///     AsRef<str> as AsRefDef;
-///     AsStr as AsStrDef;
+///     AsRef<str> as AsRefDef,
+///     AsStr as AsStrDef,
 /// ))]
 /// enum Name {
 ///     First(String),

--- a/codegen/src/util.rs
+++ b/codegen/src/util.rs
@@ -1,7 +1,12 @@
 //! Utilities for code generation.
 
 #[cfg(doc)]
-use syn::{Generics, WhereClause};
+use syn::{parse::Parse, Generics, WhereClause, WherePredicate};
+use syn::{
+    parse::{discouraged::Speculative as _, ParseStream},
+    punctuated::Punctuated,
+    token,
+};
 
 /// Extension of [`Generics`] for code generation.
 pub(crate) trait GenericsExt: Sized {
@@ -29,5 +34,51 @@ impl GenericsExt for syn::Generics {
             gens.make_where_clause().predicates.extend(c.predicates.clone());
         }
         gens
+    }
+}
+
+/// Extension of [`WhereClause`] for code generation.
+pub(crate) trait WhereClauseExt: Sized {
+    /// Parses an [`Option`]al [`WhereClause`] from the provided [`ParseStream`]
+    /// in a thrifty (non-greedy) manner, meaning that if the last
+    /// [`WherePredicate`] fails to parse, then stops parsing instead of erring.
+    ///
+    /// This function allows to parse multiple [`WhereClause`]s separated by
+    /// comma, which its [`Parse`] implementation is not capable of because of
+    /// acting greedy.
+    fn parse_thrifty_opt(input: ParseStream<'_>) -> syn::Result<Option<Self>>;
+}
+
+impl WhereClauseExt for syn::WhereClause {
+    fn parse_thrifty_opt(input: ParseStream<'_>) -> syn::Result<Option<Self>> {
+        let Some(where_token) = input.parse()? else {
+            return Ok(None);
+        };
+
+        let mut predicates = Punctuated::new();
+        predicates.push_value(input.parse()?);
+        loop {
+            if input.is_empty()
+                || input.peek(token::Brace)
+                || input.peek(token::Semi)
+                || input.peek(token::Colon) && !input.peek(token::PathSep)
+                || input.peek(token::Eq)
+            {
+                break;
+            }
+
+            let ahead = input.fork();
+            let Ok(comma) = ahead.parse::<token::Comma>() else {
+                break;
+            };
+            let Ok(predicate) = ahead.parse::<syn::WherePredicate>() else {
+                break;
+            };
+            predicates.push_punct(comma);
+            predicates.push_value(predicate);
+            input.advance_to(&ahead);
+        }
+
+        Ok(Some(Self { where_token, predicates }))
     }
 }

--- a/codegen/tests/enum_generic_param.rs
+++ b/codegen/tests/enum_generic_param.rs
@@ -23,8 +23,8 @@ impl UserType<{ USER_BORIS }> for UserTypes {
 #[delegate(for(
     for<L> EitherUser<L, UserBoris>
     where
-        L: User + 'static;
-    GenericUser<{ USER_OLEG }, { USER_BORIS }>;
+        L: User + 'static,
+    GenericUser<{ USER_OLEG }, { USER_BORIS }>,
 ))]
 trait User {
     fn name(&self) -> &str;

--- a/codegen/tests/external_traits.rs
+++ b/codegen/tests/external_traits.rs
@@ -42,8 +42,8 @@ trait AsStrDef {
 }
 
 #[delegate(derive(
-    AsRef<str> as AsRefDef;
-    AsStr as AsStrDef;
+    AsRef<str> as AsRefDef,
+    AsStr as AsStrDef,
 ))]
 enum Name {
     First(String),

--- a/codegen/tests/fail/delegate/duplicate_generics_parameters.rs
+++ b/codegen/tests/fail/delegate/duplicate_generics_parameters.rs
@@ -15,7 +15,7 @@ impl Named<String> for User {
 #[delegate(derive(
     for<T> Named<T>
     where
-        T: Named<T> + 'static;
+        T: Named<T> + 'static,
 ))]
 struct Wrapper<T>(T);
 

--- a/codegen/tests/fail/delegate/expr_in_generic_params.rs
+++ b/codegen/tests/fail/delegate/expr_in_generic_params.rs
@@ -23,7 +23,7 @@ impl<const V: u8> Versioned<V> for Created {
 }
 
 #[delegate(derive(
-    for<const V: u8> Versioned<{ V + 1 }>;
+    for<const V: u8> Versioned<{ V + 1 }>,
 ))]
 enum Events {
     Create(Created),

--- a/codegen/tests/fail/delegate/expr_in_generic_params.stderr
+++ b/codegen/tests/fail/delegate/expr_in_generic_params.stderr
@@ -25,7 +25,7 @@ error: generic parameters may not be used in const operations
 error: generic parameters may not be used in const operations
   --> tests/fail/delegate/expr_in_generic_params.rs:26:34
    |
-26 |     for<const V: u8> Versioned<{ V + 1 }>;
+26 |     for<const V: u8> Versioned<{ V + 1 }>,
    |                                  ^ cannot perform const operation using `V`
    |
    = help: const parameters may only be used as standalone arguments, i.e. `V`
@@ -33,7 +33,7 @@ error: generic parameters may not be used in const operations
 error[E0207]: the const parameter `V` is not constrained by the impl trait, self type, or predicates
   --> tests/fail/delegate/expr_in_generic_params.rs:26:9
    |
-26 |     for<const V: u8> Versioned<{ V + 1 }>;
+26 |     for<const V: u8> Versioned<{ V + 1 }>,
    |         ^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value

--- a/codegen/tests/fail/delegate/external_trait_wrong_declaration.rs
+++ b/codegen/tests/fail/delegate/external_trait_wrong_declaration.rs
@@ -22,8 +22,8 @@ trait AsStrDef {
 }
 
 #[delegate(derive(
-    AsRef<str> as AsRefDef;
-    AsStr as AsStrDef;
+    AsRef<str> as AsRefDef,
+    AsStr as AsStrDef,
 ))]
 enum Name {
     First(String),

--- a/codegen/tests/fail/delegate/external_trait_wrong_declaration.stderr
+++ b/codegen/tests/fail/delegate/external_trait_wrong_declaration.stderr
@@ -18,8 +18,8 @@ error[E0053]: method `as_ref` has an incompatible type for trait
    |                 ^^^^^^^^^ types differ in mutability
 ...
 24 | / #[delegate(derive(
-25 | |     AsRef<str> as AsRefDef;
-26 | |     AsStr as AsStrDef;
+25 | |     AsRef<str> as AsRefDef,
+26 | |     AsStr as AsStrDef,
 27 | | ))]
    | |___- in this procedural macro expansion
    |

--- a/codegen/tests/fail/delegate/external_trait_wrong_declaration.stderr
+++ b/codegen/tests/fail/delegate/external_trait_wrong_declaration.stderr
@@ -54,8 +54,8 @@ error[E0308]: mismatched types
    |   expected `&mut str` because of return type
 ...
 24 | / #[delegate(derive(
-25 | |     AsRef<str> as AsRefDef;
-26 | |     AsStr as AsStrDef;
+25 | |     AsRef<str> as AsRefDef,
+26 | |     AsStr as AsStrDef,
 27 | | ))]
    | |___- in this procedural macro expansion
    |

--- a/codegen/tests/fail/delegate/wrong_generics.rs
+++ b/codegen/tests/fail/delegate/wrong_generics.rs
@@ -17,7 +17,7 @@ impl<const V: u8> Versioned<V> for Created {
 }
 
 #[delegate(derive(
-    for<'a> Versioned<'a>;
+    for<'a> Versioned<'a>,
 ))]
 enum Events {
     Create(Created),

--- a/codegen/tests/fail/delegate/wrong_generics.stderr
+++ b/codegen/tests/fail/delegate/wrong_generics.stderr
@@ -5,14 +5,14 @@ error[E0412]: cannot find type `V` in this scope
    |                         ^ not found in this scope
 ...
 19 | / #[delegate(derive(
-20 | |     for<'a> Versioned<'a>;
+20 | |     for<'a> Versioned<'a>,
 21 | | ))]
    | |___- in this procedural macro expansion
    |
    = note: this error originates in the macro `Versioned` which comes from the expansion of the attribute macro `delegate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might be missing a type parameter
    |
-20 |     for<'a, V> Versioned<'a>;
+20 |     for<'a, V> Versioned<'a>,
    |           +++
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
@@ -52,7 +52,7 @@ error[E0747]: unresolved item provided when a constant was expected
    |                         ^
 ...
 19 | / #[delegate(derive(
-20 | |     for<'a> Versioned<'a>;
+20 | |     for<'a> Versioned<'a>,
 21 | | ))]
    | |___- in this procedural macro expansion
    |

--- a/codegen/tests/fail/delegate/wrong_generics.stderr
+++ b/codegen/tests/fail/delegate/wrong_generics.stderr
@@ -18,7 +18,7 @@ help: you might be missing a type parameter
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> tests/fail/delegate/wrong_generics.rs:20:13
    |
-20 |     for<'a> Versioned<'a>;
+20 |     for<'a> Versioned<'a>,
    |             ^^^^^^^^^---- help: remove the unnecessary generics
    |             |
    |             expected 0 lifetime arguments
@@ -32,7 +32,7 @@ note: trait defined here, with 0 lifetime parameters
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> tests/fail/delegate/wrong_generics.rs:20:13
    |
-20 |     for<'a> Versioned<'a>;
+20 |     for<'a> Versioned<'a>,
    |             ^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `V`
@@ -42,7 +42,7 @@ note: trait defined here, with 1 generic parameter: `V`
    |       ^^^^^^^^^ -----------
 help: add missing generic argument
    |
-20 |     for<'a> Versioned<'a, V>;
+20 |     for<'a> Versioned<'a, V>,
    |                         +++
 
 error[E0747]: unresolved item provided when a constant was expected
@@ -65,7 +65,7 @@ help: if this generic argument was intended as a const parameter, surround it wi
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> tests/fail/delegate/wrong_generics.rs:20:13
    |
-20 |     for<'a> Versioned<'a>;
+20 |     for<'a> Versioned<'a>,
    |             ^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `V`

--- a/codegen/tests/impls_for.rs
+++ b/codegen/tests/impls_for.rs
@@ -1,6 +1,6 @@
 use delegation::delegate;
 
-#[delegate(for(Name; FirstName; LastName))]
+#[delegate(for(Name, FirstName, LastName))]
 trait AsString {
     fn into_string(self) -> String;
     fn as_str(&self) -> &str;

--- a/codegen/tests/multiple_bounds.rs
+++ b/codegen/tests/multiple_bounds.rs
@@ -1,0 +1,86 @@
+use delegation::delegate;
+
+#[delegate(for(
+    for<U> Case2<U>
+    where
+        U: Named<N> + 'static,
+        U: Versioned,
+
+))]
+trait Named<N> {
+    fn name(&self) -> N;
+}
+
+#[delegate(for(
+    for<U> Case2<U>
+    where
+        U: Versioned + 'static,
+        U: Default,
+    for<U> Case3<U>
+    where
+        U: Versioned + 'static,
+        U: Default,
+))]
+trait Versioned {
+    fn version(&self) -> usize;
+}
+
+#[derive(Default)]
+struct User(String);
+impl Named<String> for User {
+    fn name(&self) -> String {
+        self.0.clone()
+    }
+}
+impl Versioned for User {
+    fn version(&self) -> usize {
+        self.0.len().into()
+    }
+}
+
+#[delegate(derive(
+    for<N> Named<N>
+    where
+        U: Named<N> + 'static,
+        U: Versioned,
+    Versioned
+    where
+        U: Versioned + 'static,
+        U: Default,
+))]
+enum Case1<U> {
+    User(U),
+}
+
+#[delegate]
+struct Case2<U>(U);
+
+#[delegate(derive(
+   for<N> Named<N>
+   where
+       U: Named<N> + 'static,
+       U: Versioned,
+))]
+enum Case3<U> {
+    Case1(Case1<U>),
+    #[allow(dead_code)]
+    Case2(Case2<U>),
+}
+
+#[test]
+fn derives_with_generics() {
+    let user1 = Case1::User(User("User".to_string()));
+    assert_eq!(user1.name(), "User");
+    assert_eq!(user1.version(), 4);
+
+    let user2 = Case2(User("User2".to_string()));
+    assert_eq!(user2.name(), "User2");
+    assert_eq!(user2.version(), 5);
+
+    let user3 = Case3::Case1(Case1::User(User("Charlie".to_string())));
+    assert_eq!(user3.name(), "Charlie");
+    assert_eq!(user3.version(), 7);
+    let user4 = Case3::Case2(Case2(User("Tom".to_string())));
+    assert_eq!(user4.name(), "Tom");
+    assert_eq!(user4.version(), 3);
+}

--- a/codegen/tests/scope_consistent.rs
+++ b/codegen/tests/scope_consistent.rs
@@ -28,7 +28,7 @@ mod b {
     #[delegation::delegate(derive(
         super::a::ToMyStruct<Inner>
         where
-            Inner: Copy + Into<super::MyStruct> + 'static;
+            Inner: Copy + Into<super::MyStruct> + 'static,
         for<'a> super::a::ToGeneric<'a, Inner>
         where
             Inner: Copy + 'static,

--- a/codegen/tests/sealed_external_traits.rs
+++ b/codegen/tests/sealed_external_traits.rs
@@ -48,8 +48,8 @@ mod sealed {
 }
 
 #[delegate(derive(
-    AsRef<str> as sealed::AsRefDef;
-    AsStr as sealed::AsStrDef;
+    AsRef<str> as sealed::AsRefDef,
+    AsStr as sealed::AsStrDef,
 ))]
 enum Name {
     First(String),

--- a/codegen/tests/trait_and_type_generic_param.rs
+++ b/codegen/tests/trait_and_type_generic_param.rs
@@ -3,7 +3,7 @@ use delegation::delegate;
 #[delegate(for(
     for<U> Case2<U>
     where
-        U: Named<N> + 'static;
+        U: Named<N> + 'static,
 ))]
 trait Named<N> {
     fn name(&self) -> N;

--- a/codegen/tests/trait_and_type_generic_param.rs
+++ b/codegen/tests/trait_and_type_generic_param.rs
@@ -19,7 +19,7 @@ impl Named<String> for User {
 #[delegate(derive(
     for<N> Named<N>
     where
-        U: Named<N> + 'static;
+        U: Named<N> + 'static,
 ))]
 enum Case1<U> {
     User(U),
@@ -31,7 +31,7 @@ struct Case2<U>(U);
 #[delegate(derive(
    Named<String>
    where
-       U: Named<String> + 'static;
+       U: Named<String> + 'static,
 ))]
 enum Case3<U> {
     Case1(Case1<U>),

--- a/codegen/tests/trait_generic_param.rs
+++ b/codegen/tests/trait_generic_param.rs
@@ -23,8 +23,8 @@ trait Versioned<const V: u8> {
 }
 
 #[delegate(derive(
-    Named<String>;
-    for<const V: u8> Versioned<{ V }>;
+    Named<String>,
+    for<const V: u8> Versioned<{ V }>,
 ))]
 enum Users {
     Oleg(UserOleg),

--- a/codegen/tests/traits_with_same_name.rs
+++ b/codegen/tests/traits_with_same_name.rs
@@ -30,7 +30,7 @@ mod last_name {
     }
 }
 
-#[delegate(derive(first_name::AsStr; last_name::AsStr))]
+#[delegate(derive(first_name::AsStr, last_name::AsStr))]
 struct Name(String);
 
 #[test]

--- a/codegen/tests/type_generic_param.rs
+++ b/codegen/tests/type_generic_param.rs
@@ -23,7 +23,7 @@ where
 #[delegate(derive(
     Named<String>
     where
-        U: Named<String> + 'static;
+        U: Named<String> + 'static,
 ))]
 enum Case2<U> {
     Admin(U),

--- a/codegen/tests/unsafe.rs
+++ b/codegen/tests/unsafe.rs
@@ -22,7 +22,7 @@ unsafe impl AsString for String {
     }
 }
 
-#[delegate(derive(AsStr; AsString))]
+#[delegate(derive(AsStr, AsString))]
 struct Name(String);
 
 #[test]


### PR DESCRIPTION
## Synopsis

At the moment, multiple derives are separated by semicolon (`;`):
```rust
#[delegate(derive(
    AsRef<str> as AsRefDef;
    AsStr as AsStrDef;
))]
enum Name {
    First(String),
}
```
Which kinda looks alien in comparison with the standard `#[derive(..)]` attribute where things are separated by comma.



## Solution

Instead of using semicolon, we can use just comma. There should be no ambiguity between multiple bounds in `where` clause and multiple derives, since they cannot be misinterpreted in any way. The only obstacle is possible greediness of the `syn::Punctuated` parsing (not considering multiple where clauses and returning error early), which is used now. However, we always can overcome it by introducing custom parsing in this place.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
